### PR TITLE
[WIP] Configure CI for interface tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,4 +16,4 @@ jobs:
     - name: Run Logic Tests
       run: npm run test:ci
     - name: Run Interface Tests
-      run: npm run build && npx start-server-and-test start 3000 'olsk-spec-ui --ci'
+      run: npm run build --ci && npx start-server-and-test start 3000 'olsk-spec-ui --ci'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,4 +16,4 @@ jobs:
     - name: Run Logic Tests
       run: npm run test:ci
     - name: Run Interface Tests
-      run: npx start-server-and-test start 3000 'olsk-spec-ui --ci'
+      run: npm run build && npx start-server-and-test start 3000 'olsk-spec-ui --ci'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: Tests
+name: Test logic and interface
 
 on: [push, pull_request]
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,5 +13,7 @@ jobs:
         node-version: '14.x'
     - name: Setup
       run: npm run setup
-    - name: Tests
+    - name: Run Logic Tests
       run: npm run test:ci
+    - name: Run Interface Tests
+      run: npx start-server-and-test start 3000 'olsk-spec-ui --ci'

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "// I sacrifice myself for the commas of others": null
   },
   "devDependencies": {
+    "start-server-and-test": "latest",
     "OLSKPithToolchain": "olsk/OLSKPithToolchain",
     "OLSKRollupScaffold": "olsk/OLSKRollupScaffold",
 


### PR DESCRIPTION
Here's an example of configuring CI to run interface tests as well. As you can see from my fork, it doesn't work yet but I guess we can use this PR to investigate what's the problem. If you eventually fix it, feel free to copy the changes and format them as you want on your own branch, don't worry about keeping my commits :).

The only thing that's new here is the [start-server-and-test](https://github.com/bahmutov/start-server-and-test) dependency. This is necessary because it helps you start the server before running the tests, and stops it once the tests are done. That's necessary in CI because if you don't do it this way, the pipeline may not finish if the server is still running. You can read their documentation for more info.

I'm not getting the same amount of errors locally, which is weird, but the type of errors I get are similar. We can see that 343 tests are passing, so at least something is working.